### PR TITLE
feat: Implement cPanel storage functionality with directory copying a…

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,0 +1,5 @@
+deployment:
+    tasks:
+        - export DEPLOYPATH=/home/softcont/public_html/demo/
+        - cd ./public
+        - find . -type f ! -name "index.php" -exec sh -c 'mkdir -p "$DEPLOYPATH/$(dirname {})" && cp {} "$DEPLOYPATH/$(dirname {})"' \;

--- a/app/Http/Middleware/Cpanel/StorageHability.php
+++ b/app/Http/Middleware/Cpanel/StorageHability.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware\Cpanel;
+
+use App\Services\Utils\Storage\StorageForCpanelService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class StorageHability
+{
+    protected $storageService;
+
+    public function __construct(StorageForCpanelService $Service)
+    {
+        $this->storageService = $Service;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+        $this->storageService->copyDirectory();
+
+        return $response;
+    }
+}

--- a/app/Services/Utils/Storage/StorageForCpanelService.php
+++ b/app/Services/Utils/Storage/StorageForCpanelService.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services\Utils\Storage;
+
+use Illuminate\Support\Facades\Log;
+
+class StorageForCpanelService
+{
+    private string $originPath;
+
+    private string $destinationPath;
+
+    public function __construct()
+    {
+        $this->originPath = config('cpanel.storage.origin_path');
+        $this->destinationPath = config('cpanel.storage.destination_path');
+    }
+
+    /**
+     * Copia recursivamente un directorio al destino.
+     *
+     * @param  string|null  $src  Directorio de origen (opcional)
+     * @param  string|null  $dst  Directorio de destino (opcional)
+     */
+    public function copyDirectory(?string $src = null, ?string $dst = null): void
+    {
+        $src = $src ?? $this->originPath;
+        $dst = $dst ?? $this->destinationPath;
+
+        if (! $this->validateDirectories([$src])) {
+            Log::info('Cancelando la copia: el directorio de origen no existe.');
+
+            return;
+        }
+
+        if (! is_dir($dst)) {
+            $this->createDirectory($dst);
+        }
+
+        $dir = opendir($src);
+        if (! $dir) {
+            Log::error("No se pudo abrir el directorio: $src");
+
+            return;
+        }
+
+        try {
+            while (($file = readdir($dir)) !== false) {
+                if ($file === '.' || $file === '..') {
+                    continue;
+                }
+
+                $srcPath = $src.DIRECTORY_SEPARATOR.$file;
+                $dstPath = $dst.DIRECTORY_SEPARATOR.$file;
+
+                if (is_dir($srcPath)) {
+                    $this->copyDirectory($srcPath, $dstPath);
+                } else {
+                    $this->copyFile($srcPath, $dstPath);
+                }
+            }
+        } finally {
+            closedir($dir);
+        }
+    }
+
+    /**
+     * Valida que los directorios indicados existan.
+     *
+     * @param  array  $directories  Rutas de directorios a validar.
+     * @return bool True si todos existen, false en caso contrario.
+     */
+    private function validateDirectories(array $directories): bool
+    {
+        foreach ($directories as $path) {
+            if (! is_dir($path)) {
+                Log::error("El directorio no existe: $path");
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Crea un directorio si no existe.
+     *
+     * @param  string  $path  Ruta del directorio a crear.
+     */
+    private function createDirectory(string $path): void
+    {
+        if (! is_dir($path) && ! mkdir($path, 0755, true) && ! is_dir($path)) {
+            Log::error("No se pudo crear el directorio: $path");
+        }
+    }
+
+    /**
+     * Copia un archivo si no existe en el destino o si es más reciente.
+     *
+     * @param  string  $src  Ruta del archivo origen.
+     * @param  string  $dst  Ruta del archivo destino.
+     */
+    private function copyFile(string $src, string $dst): void
+    {
+        if (! file_exists($dst) || filemtime($src) > filemtime($dst)) {
+            if (! copy($src, $dst)) {
+                Log::error("No se pudo copiar el archivo: $src → $dst");
+            }
+        }
+    }
+}

--- a/config/cpanel.php
+++ b/config/cpanel.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Configuración de almacenamiento para cPanel
+    |--------------------------------------------------------------------------
+    |
+    | Define las rutas de origen y destino para la copia de directorios
+    | en entornos con cPanel. Estos valores pueden ser sobrescritos
+    | en el archivo .env si es necesario.
+    |
+    */
+
+    'storage' => [
+        'origin_path' => env('CPANEL_ORIGIN_PATH'),
+        'destination_path' => env('CPANEL_DESTINATION_PATH'),
+    ],
+];


### PR DESCRIPTION
This pull request introduces a new system for handling file and directory copying for cPanel deployments, focusing on automating and improving the reliability of storage operations during deployment. The changes include configuration, service, and middleware additions to support recursive directory copying based on environment variables, and an update to the deployment task list.

**Deployment automation and storage management:**

* Added a deployment task in `.cpanel.yml` to copy all files (except `index.php`) from the `public` directory to the cPanel deployment path, ensuring correct file placement during deployment.

**New storage service and middleware:**

* Introduced `StorageForCpanelService` in `app/Services/Utils/Storage/StorageForCpanelService.php` to recursively copy directories and files, validate directory existence, create missing directories, and handle file overwrites based on modification time.
* Added `StorageHability` middleware in `app/Http/Middleware/Cpanel/StorageHability.php` to invoke the storage service's copy operation after each request, integrating storage management into the request lifecycle.

**Configuration support:**

* Created `config/cpanel.php` to define origin and destination paths for storage operations, making them configurable via environment variables for flexible deployment setups.…nd configuration setup
