### PR TITLE
feat: Add API routes for data creation and storage

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Actions\ExternalServices\Reniec\GetReniecData;
 use App\Actions\ExternalServices\Sunat\GetSunatData;
+use App\Http\Controllers\Api\DataController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -17,4 +18,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/sunat/{dni}', function (Request $request) {
         return GetSunatData::run($request->dni);
     });
+});
+
+Route::prefix('v1')->group(function () {
+    Route::get('/data', [DataController::class, 'create'])->name('data');
+    Route::post('/data/store', [DataController::class, 'store'])->name('data.store');
 });


### PR DESCRIPTION
This pull request adds new API endpoints under the `/v1` prefix to support data retrieval and storage functionality. The changes primarily introduce routing for new features and include the necessary controller for handling these requests.

New API endpoints:

* Added a GET route `/v1/data` and a POST route `/v1/data/store` handled by the `DataController` for retrieving and storing data, respectively.
* Imported the `DataController` in `routes/api.php` to support the new routes.
