### PR TITLE
feat: Add scripts for container management and code formatting

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
@@ -22,6 +23,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        if ($this->app->environment('production')) {
+            URL::forceScheme('https');
+        }
+
         app(\Spatie\Permission\PermissionRegistrar::class)
             ->setPermissionClass(Permission::class)
             ->setRoleClass(Role::class);

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["laravel", "framework"],
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "aymanalhattami/filament-slim-scrollbar": "^2.1",
         "bezhansalleh/filament-shield": "^3.3",
         "eightynine/filament-advanced-widgets": "^3.0",

--- a/enter-container.sh
+++ b/enter-container.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# filepath: /home/dev/Sites/inventory/enter-container.sh
+
+# Start Docker Compose in detached mode
+docker compose up -d
+
+# Wait for containers to be ready
+sleep 10
+
+# Get the container ID for the Laravel app (inventory-laravel.test-1)
+CONTAINER_ID=$(basename $(pwd) | tr '[:upper:]' '[:lower:]' | xargs -I {} docker ps --filter "name={}-laravel.test-1" --format "{{.ID}}")
+
+if [ -z "$CONTAINER_ID" ]; then
+    echo "Laravel container not found. Please check if Docker Compose started correctly."
+    exit 1
+fi
+
+# Enter the container interactively
+docker exec -it $CONTAINER_ID bash

--- a/fixformat.sh
+++ b/fixformat.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Colores para mensajes
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Iniciando proceso de formateo de código...${NC}"
+
+# Ejecutar Laravel Pint
+echo -e "\n${GREEN}Ejecutando Laravel Pint...${NC}"
+./vendor/bin/pint
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Error ejecutando Laravel Pint${NC}"
+    exit 1
+fi
+
+# Ejecutar npm format
+echo -e "\n${GREEN}Ejecutando npm format...${NC}"
+npm run format
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Error ejecutando npm format${NC}"
+    exit 1
+fi
+
+# Ejecutar npm lint:fix
+echo -e "\n${GREEN}Ejecutando npm lint:fix...${NC}"
+npm run lint:fix
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Error ejecutando npm lint:fix${NC}"
+    exit 1
+fi
+
+echo -e "\n${GREEN}¡Proceso de formateo completado exitosamente!${NC}"

--- a/fixpermissions.sh
+++ b/fixpermissions.sh
@@ -1,0 +1,14 @@
+# filepath: /home/dev/dev/app/automate_permissions.sh
+#!/bin/bash
+
+# Etapa todos los cambios
+git add .
+
+# Aplica chmod 777 recursivamente (requiere sudo)
+sudo chmod -R 777 .
+
+# Restaura el directorio de trabajo al último commit (deshace cambios de chmod)
+git restore .
+
+# Desetapa todos los cambios
+git reset HEAD .

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "html",
             "dependencies": {
                 "@vitejs/plugin-vue": "^6.0.1"
             },
@@ -113,7 +112,6 @@
             "os": [
                 "aix"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -130,7 +128,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -147,7 +144,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -164,7 +160,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -181,7 +176,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -198,7 +192,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -215,7 +208,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -232,7 +224,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -249,7 +240,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -266,7 +256,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -283,7 +272,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -300,7 +288,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -317,7 +304,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -334,7 +320,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -351,7 +336,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -368,7 +352,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -385,7 +368,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -402,7 +384,6 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -419,7 +400,6 @@
             "os": [
                 "netbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -436,7 +416,6 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -453,7 +432,6 @@
             "os": [
                 "openbsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -470,7 +448,6 @@
             "os": [
                 "openharmony"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -487,7 +464,6 @@
             "os": [
                 "sunos"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -504,7 +480,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -521,7 +496,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -538,7 +512,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -972,8 +945,7 @@
             "optional": true,
             "os": [
                 "android"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.46.2",
@@ -986,8 +958,7 @@
             "optional": true,
             "os": [
                 "android"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.46.2",
@@ -1000,8 +971,7 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
             "version": "4.46.2",
@@ -1014,8 +984,7 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
             "version": "4.46.2",
@@ -1028,8 +997,7 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
             "version": "4.46.2",
@@ -1042,8 +1010,7 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.46.2",
@@ -1056,8 +1023,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
             "version": "4.46.2",
@@ -1070,8 +1036,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
             "version": "4.46.2",
@@ -1084,8 +1049,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
             "version": "4.46.2",
@@ -1098,8 +1062,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
             "version": "4.46.2",
@@ -1112,8 +1075,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
             "version": "4.46.2",
@@ -1126,8 +1088,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.46.2",
@@ -1140,8 +1101,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
             "version": "4.46.2",
@@ -1154,8 +1114,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
             "version": "4.46.2",
@@ -1168,8 +1127,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.46.2",
@@ -1182,8 +1140,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
             "version": "4.46.2",
@@ -1196,8 +1153,7 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
             "version": "4.46.2",
@@ -1210,8 +1166,7 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
             "version": "4.46.2",
@@ -1224,8 +1179,7 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
             "version": "4.46.2",
@@ -1238,8 +1192,7 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/@tailwindcss/forms": {
             "version": "0.5.10",
@@ -1620,6 +1573,7 @@
             "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.39.0",
                 "@typescript-eslint/types": "8.39.0",
@@ -1928,6 +1882,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2153,6 +2108,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001726",
                 "electron-to-chromium": "^1.5.173",
@@ -2691,7 +2647,6 @@
             "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -2756,6 +2711,7 @@
             "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -4310,6 +4266,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -4614,7 +4571,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
             "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -5005,6 +4961,7 @@
             "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -5117,7 +5074,6 @@
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
             "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.3"
@@ -5134,7 +5090,6 @@
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -5401,7 +5356,6 @@
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -5432,6 +5386,7 @@
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.18.tgz",
             "integrity": "sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.5.18",
                 "@vue/compiler-sfc": "3.5.18",
@@ -5630,6 +5585,7 @@
             "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
             "devOptional": true,
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# filepath: /home/dev/Sites/inventory/start-dev.sh
+# Start Docker Compose in detached mode
+docker compose up -d
+
+# Wait for containers to be ready
+sleep 10
+
+# Get the container ID for the Laravel app (inventory-laravel.test-1)
+CONTAINER_ID=$(basename $(pwd) | tr '[:upper:]' '[:lower:]' | xargs -I {} docker ps --filter "name={}-laravel.test-1" --format "{{.ID}}")
+
+if [ -z "$CONTAINER_ID" ]; then
+    echo "Laravel container not found. Please check if Docker Compose started correctly."
+    exit 1
+fi
+
+# Execute npm install inside the container
+docker exec $CONTAINER_ID npm i
+
+# Run npm run dev interactively inside the container (this will attach the terminal)
+docker exec -it $CONTAINER_ID npm run dev


### PR DESCRIPTION
This pull request introduces several new utility scripts to streamline development tasks and makes a key configuration update to enforce HTTPS in production. The most important changes are grouped below:

**Environment Configuration:**

* Enforces HTTPS scheme for all URLs when running in production environment by updating the `AppServiceProvider` (`app/Providers/AppServiceProvider.php`). [[1]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR6) [[2]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR26-R29)

**Development Automation Scripts:**

* Adds `start-dev.sh` to automate starting Docker containers, installing npm dependencies, and launching the development server inside the Laravel container.
* Adds `enter-container.sh` to automate entering the Laravel Docker container interactively after ensuring it is running.
* Adds `fixformat.sh` to run Laravel Pint, npm formatting, and linting scripts with color-coded status messages for code quality enforcement.
* Adds `fixpermissions.sh` to temporarily set file permissions to 777 using `chmod`, then restore the working directory and unstaged changes for permission troubleshooting.

>