### PR TITLE
fix: add missing PHP extensions to composer.json requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
+        "ext-bcmath": "*",  
+        "ext-zip": "*",       
+        "ext-intl": "*",       
         "aymanalhattami/filament-slim-scrollbar": "^2.1",
         "bezhansalleh/filament-shield": "^3.3",
         "eightynine/filament-advanced-widgets": "^3.0",


### PR DESCRIPTION
This pull request updates the project dependencies in `composer.json` to ensure required PHP extensions are explicitly listed. This helps prevent runtime errors due to missing extensions and improves environment consistency.

Dependency management:

* Added `ext-bcmath`, `ext-zip`, and `ext-intl` as required PHP extensions to the `require` section of `composer.json`.


>ta bien 