### PR TITLE
feat: implement FilamentUser interface and add panel access method to…

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,8 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 
 use App\Traits\SecuritySystemTrait;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -13,7 +15,7 @@ use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser
 {
     use HasApiTokens;
 
@@ -85,5 +87,10 @@ class User extends Authenticatable
     public function addresses()
     {
         return $this->morphMany(Addresse::class, 'addressable');
+    }
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
This pull request updates the `User` model to improve compatibility with the Filament admin panel system by implementing the required interface and adding a method for panel access control.

Filament integration:

* Added `FilamentUser` interface implementation to the `User` class, enabling Filament-specific features and permissions.
* Imported `Filament\Models\Contracts\FilamentUser` and `Filament\Panel` to support Filament panel functionality.
* Added the `canAccessPanel(Panel $panel): bool` method to always allow users to access Filament panels, satisfying Filament's requirements for user access control.… User model